### PR TITLE
Added an extensible filter over the name data.

### DIFF
--- a/user-scan/name-bad-word-list
+++ b/user-scan/name-bad-word-list
@@ -1,0 +1,13 @@
+Mr.
+Mrs.
+Sr.
+Jr.
+CPA
+PMP
+Dr.
+,
+.
+CEO
+CTO
+CIO
+CFO

--- a/user-scan/scripts/clean-harvested-names.sh
+++ b/user-scan/scripts/clean-harvested-names.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Apply a filter to all of the names to strip bad words and characters.
+
+while read NAME
+do
+    $USER_SCAN_SCRIPTS/strip-name.sh "$NAME" < $SCRIPT_DIRECTORY/user-scan/name-bad-word-list
+done < "${1:-/dev/stdin}"

--- a/user-scan/scripts/strip-name.sh
+++ b/user-scan/scripts/strip-name.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Strip matched words from names. This is used to remove patterns like:
+# 'Jr.', 'Sr.', 'CPA', etc. from names.
+#
+# The second input (or stdin) is a file containing the words to strip, one per line.
+# The first input is the line to strip from.
+
+# echo ${TMP//Mr.} | sed 's/^[ \t]*//' | sed 's/[ \t]*$//' | sed 's/  */ /'
+
+LINE="$1"
+
+while read STRIPPED_WORD
+do
+    LINE="${LINE//$STRIPPED_WORD}"
+done < "${2:-/dev/stdin}"
+
+echo $LINE \
+    | sed 's/^[ \t]*//' \
+    | sed 's/[ \t]*$//' \
+    | sed 's/[ \t][ \t]*/ /'
+

--- a/user-scan/user-scan.sh
+++ b/user-scan/user-scan.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 
-echo "> Attempting to harvest users for company '${COMPANY_NAME}' from LinkedIn."
+echo "> Attempting to harvest users for company '$COMPANY_NAME' from LinkedIn."
 
-$SCRIPT_DIRECTORY/user-scan/scripts/harvest-linkedin.sh "${COMPANY_NAME}" 100 > $LINKEDIN_RESULTS
+$USER_SCAN_SCRIPTS/harvest-linkedin.sh "$COMPANY_NAME" 100 \
+    | $USER_SCAN_SCRIPTS/clean-harvested-names.sh \
+    | uniq -u \
+    > $LINKEDIN_RESULTS
 
 echo -e "\t+ Found $(cat $LINKEDIN_RESULTS | wc -l) users."
 echo ""
 
 touch $POSSIBLE_EMAILS
-$SCRIPT_DIRECTORY/user-scan/scripts/possible-emails.sh "${EMAIL_DOMAIN}" \
+$USER_SCAN_SCRIPTS/possible-emails.sh "$EMAIL_DOMAIN" \
     < $LINKEDIN_RESULTS \
     > $POSSIBLE_EMAILS
 
 echo "> Attempting to identify compromised email style based on HaveIBeenPwned."
 
 touch $COMPROMISED_STYLE
-$SCRIPT_DIRECTORY/user-scan/scripts/hibp-filter.sh \
+$USER_SCAN_SCRIPTS/hibp-filter.sh \
     < $POSSIBLE_EMAILS \
     > $COMPROMISED_STYLE
 
@@ -24,6 +27,6 @@ touch $COMPROMISED_EMAILS
 if [ -s $COMPROMISED_STYLE ]; then
     cat $POSSIBLE_EMAILS | grep $COMPROMISED_STYLE > $PROBABLE_EMAILS
     cat $PROBABLE_EMAILS \
-        | $SCRIPT_DIRECTORY/user-scan/scripts/hibp-scan.sh \
+        | $USER_SCAN_SCRIPTS/hibp-scan.sh \
         > $COMPROMISED_EMAILS
 fi


### PR DESCRIPTION
See the file user-scan/name-bad-word-list for the current list of items
(one-per-line) stripped out from names. Removals are literal and case
sensitive so we should account for that. Also be careful since the words
are literal we might unintentionally strip out a real part of a name

One thing we could add in the future is a way to remove isolated letters
and such.

@theabraxas if you want to test this yourself before merging it, you can always do:

```
git pull
git checkout defect/11-bad-name-data
```

To checkout the branch, and then run only a user scan.