### PR TITLE
Feature/39 convert whatweb output to json

### DIFF
--- a/domain-scan/scripts/whatweb.sh
+++ b/domain-scan/scripts/whatweb.sh
@@ -6,6 +6,6 @@ SUBDOMAIN_FILE="${2}"
 while read SUBDOMAIN; do
     # For each subdomain, execute WhatWeb and dump the raw results to a file.
     OUTPUT="${SCAN_DIRECTORY}/${SUBDOMAIN}.txt"
-    ${BATTALION_WHATWEB_HOME}/whatweb --color=never --no-errors -a1 -v "${SUBDOMAIN}" > "${OUTPUT}"
+    JSONOUTPUT="${SCAN_DIRECTORY}/${SUBDOMAIN}.json"
+    ${BATTALION_WHATWEB_HOME}/whatweb --color=never --no-errors -a1 -v "${SUBDOMAIN}" --log-json="${JSONOUTPUT}" > "${OUTPUT}"
 done <${SUBDOMAIN_FILE}
-


### PR DESCRIPTION
Added JSON output for WhatWeb - still keeping .txt for now as that is how our web-tech filters work. Will want to create a new method for filtering things like wordpress/drupal/joomla/iis/nginx/apache technologies.